### PR TITLE
Add example docstring

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,33 @@
+# codecov can find this file anywhere in the repo, so we don't need to clutter
+# the root folder.
+#comment: false
+
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  status:
+    patch:
+      default:
+        target: '80'
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+    project:
+      default: false
+      library:
+        target: auto
+        if_no_uploads: error
+        if_not_found: success
+        if_ci_failed: failure
+        paths: '!*/tests/.*'
+
+      tests:
+        target: 97.9%
+        paths: '*/tests/.*'
+
+flags:
+  tests:
+    paths:
+      - tests/

--- a/pytentiostat/reporter.py
+++ b/pytentiostat/reporter.py
@@ -2,6 +2,21 @@ import pandas as pd
 
 
 def save_data_to_file(data, filename="Place_Holder.csv"):
+    '''
+    Saves measured data to a csv file
+
+    Parameters
+    ----------
+    data : array
+        the data that will be saved
+    filename : string
+        the name of the file to save. Optional. Defaults to Place_Holder.csv
+
+    Returns
+    -------
+        nothing
+    '''
+
     # These will be imported from config
     export_file_destination = "Place/holder/path"
 


### PR DESCRIPTION
As the functions settle down (or preferrably before!) we need to add docstrings.  I am adding an example docstring in ``reporter.py`` to use as a model.  It is based on numpy standards which we use in the group.