### PR TITLE
ENH: Calibrate to make target match actual voltage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,11 +10,11 @@ To post questions about anything to do with pytentiostat, please submit an issue
 
 pytentiostat provides a Python API package to the JUAMI potentiostat
 
-The goal of the xpdAn package is to simplify your analysis workflow during beamtime, so that you can focus more on the scientific aspects of your experiment.
+The goal of the pytentiostat package is to provide a free, user-friendly interface to run electrochemistry experiments with the JUAMI potentiostat
 
 To get started, please go to :ref:`quick_start`
 
-If you have suggestions for new features in xpdAcq, or want to report a bug or simply ask a question about the software, please post it as a new thread at XPD-Users
+If you have suggestions for new features in pytentiostat, or want to report a bug or simply ask a question about the software, please send an email to Austin Plymill at austinplymill2021@u.northwestern.edu.
 
 .. toctree::
    :maxdepth: 2

--- a/pytentiostat/config.yml
+++ b/pytentiostat/config.yml
@@ -22,7 +22,8 @@ chronoamperometry:
 #Only advanced users should edit advanced parameters 
 advanced_parameters:
   conversion_factor: 4.798
-  setpoint_adjuster: 1.03
+  setpoint_gain: 1.03
+  setpoint_offset: 0
   shunt_resistor: 0.202 #mOhm
   time_step: 0.003  #s
   average_number: 9

--- a/pytentiostat/config.yml
+++ b/pytentiostat/config.yml
@@ -1,6 +1,6 @@
 #General parameters to edit for an experiment
 general_parameters:
-  experiment_type: CV
+  experiment_type: LSV
   rest_time: 0.5 #s
   data_output_filename: MyData
   data_output_path: desktop
@@ -16,11 +16,12 @@ cyclic_voltammetry:
   number_of_cycles: 1
 chronoamperometry:
   voltage: 1 #V
-  time: 10 #s
+  time: 15 #s
  
 #Only advanced users should edit advanced parameters 
 advanced_parameters:
-  conversion_factor: 4.798  
+  conversion_factor: 4.798
+  setpoint_adjuster: 1.03
   shunt_resistor: 0.202 #mOhm
   time_step: 0.02  #us
   average_number: 9

--- a/pytentiostat/config.yml
+++ b/pytentiostat/config.yml
@@ -2,6 +2,7 @@
 general_parameters:
   experiment_type: LSV
   rest_time: 0.5 #s
+  step_number: 100
   data_output_filename: MyData
   data_output_path: desktop
 linear_sweep_voltammetry:
@@ -23,6 +24,5 @@ advanced_parameters:
   conversion_factor: 4.798
   setpoint_adjuster: 1.03
   shunt_resistor: 0.202 #mOhm
-  time_step: 0.02  #us
+  time_step: 0.003  #s
   average_number: 9
-  time_factor: 1.35

--- a/pytentiostat/config_reader.py
+++ b/pytentiostat/config_reader.py
@@ -106,7 +106,7 @@ def get_steps(config_data):
 def get_adv_params(adv_config_data):
     conversion_factor = adv_config_data["advanced_parameters"]["conversion_factor"]
     set_gain = adv_config_data["advanced_parameters"]["setpoint_adjuster"]
-    set_offset = adv_config_data["advanced_parameters"]["setpoint_offset
+    set_offset = adv_config_data["advanced_parameters"]["setpoint_offset"]
     shunt_resistor = adv_config_data["advanced_parameters"]["shunt_resistor"]
     time_step = adv_config_data["advanced_parameters"]["time_step"]
     average_number = adv_config_data["advanced_parameters"]["average_number"]

--- a/pytentiostat/config_reader.py
+++ b/pytentiostat/config_reader.py
@@ -105,14 +105,16 @@ def get_steps(config_data):
 
 def get_adv_params(adv_config_data):
     conversion_factor = adv_config_data["advanced_parameters"]["conversion_factor"]
-    setpoint_adjuster = adv_config_data["advanced_parameters"]["setpoint_adjuster"]
+    set_gain = adv_config_data["advanced_parameters"]["setpoint_adjuster"]
+    set_offset = adv_config_data["advanced_parameters"]["setpoint_offset
     shunt_resistor = adv_config_data["advanced_parameters"]["shunt_resistor"]
     time_step = adv_config_data["advanced_parameters"]["time_step"]
     average_number = adv_config_data["advanced_parameters"]["average_number"]
 
     return (
         conversion_factor,
-        setpoint_adjuster,
+        set_gain,
+        set_offset,
         shunt_resistor,
         time_step,
         average_number,

--- a/pytentiostat/config_reader.py
+++ b/pytentiostat/config_reader.py
@@ -96,6 +96,11 @@ def get_rest(config_data):
     rest_time = config_data["general_parameters"]["rest_time"]
 
     return rest_time
+    
+def get_steps(config_data):
+    step_number = config_data["general_parameters"]["step_number"]
+    
+    return step_number
 
 
 def get_adv_params(adv_config_data):
@@ -104,7 +109,6 @@ def get_adv_params(adv_config_data):
     shunt_resistor = adv_config_data["advanced_parameters"]["shunt_resistor"]
     time_step = adv_config_data["advanced_parameters"]["time_step"]
     average_number = adv_config_data["advanced_parameters"]["average_number"]
-    time_factor = adv_config_data["advanced_parameters"]["time_factor"]
 
     return (
         conversion_factor,
@@ -112,7 +116,6 @@ def get_adv_params(adv_config_data):
         shunt_resistor,
         time_step,
         average_number,
-        time_factor,
     )
 def check_config_inputs(arg):
     """

--- a/pytentiostat/config_reader.py
+++ b/pytentiostat/config_reader.py
@@ -100,6 +100,7 @@ def get_rest(config_data):
 
 def get_adv_params(adv_config_data):
     conversion_factor = adv_config_data["advanced_parameters"]["conversion_factor"]
+    setpoint_adjuster = adv_config_data["advanced_parameters"]["setpoint_adjuster"]
     shunt_resistor = adv_config_data["advanced_parameters"]["shunt_resistor"]
     time_step = adv_config_data["advanced_parameters"]["time_step"]
     average_number = adv_config_data["advanced_parameters"]["average_number"]
@@ -107,6 +108,7 @@ def get_adv_params(adv_config_data):
 
     return (
         conversion_factor,
+        setpoint_adjuster,
         shunt_resistor,
         time_step,
         average_number,

--- a/pytentiostat/config_reader.py
+++ b/pytentiostat/config_reader.py
@@ -105,7 +105,7 @@ def get_steps(config_data):
 
 def get_adv_params(adv_config_data):
     conversion_factor = adv_config_data["advanced_parameters"]["conversion_factor"]
-    set_gain = adv_config_data["advanced_parameters"]["setpoint_adjuster"]
+    set_gain = adv_config_data["advanced_parameters"]["setpoint_gain"]
     set_offset = adv_config_data["advanced_parameters"]["setpoint_offset"]
     shunt_resistor = adv_config_data["advanced_parameters"]["shunt_resistor"]
     time_step = adv_config_data["advanced_parameters"]["time_step"]

--- a/pytentiostat/main.py
+++ b/pytentiostat/main.py
@@ -10,7 +10,8 @@ config_data = parse_config_file()
 com, board, a0, a2, d9 = startup_routine()
 
 # Run the experiment and get the config_data
-times, voltages, currents = experiment(config_data, board, a0, a2, d9)
+board_objects = (board, a0, a2, d9)
+times, voltages, currents = experiment(config_data, *board_objects)
 
 # Generate a config_data report
 collected_data = zip(times, voltages, currents)

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -158,14 +158,14 @@ def experiment(config_data, board, a0, a2, d9):
 
     """
     # Constants for every experiment
-    conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number = cr.get_adv_params(
+    conversion_factor, set_gain, set_offset, shunt_resistor, time_step, average_number = cr.get_adv_params(
         config_data
     )
     
     step_number = cr.get_steps(config_data)
 
     # Check the values in advanced parameters in config.yml
-    for i in [conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number]:
+    for i in [conversion_factor, setpoint_gain, setpoint_offset, shunt_resistor, time_step, average_number]:
         if not cr.check_config_inputs(i):
             print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in adv.config.yml is not a number" + "\x1b[0m")
             sys.exit()
@@ -187,7 +187,7 @@ def experiment(config_data, board, a0, a2, d9):
         voltage_range = abs(end_voltage - start_voltage)  # V
         time_for_range = voltage_range / (sweep_rate / 1000)  # s
 
-        steps_list = np.linspace(normalized_start, normalized_end, num=step_number+1)*setpoint_adjuster
+        steps_list = np.linspace(normalized_start, normalized_end, num=step_number+1)*set_gain+set_offset
 
     elif exp_type == "CA":
 
@@ -199,7 +199,7 @@ def experiment(config_data, board, a0, a2, d9):
                 sys.exit()
         normalized_voltage = (voltage + 2.5) / 5
 
-        steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number+1)*setpoint_adjuster
+        steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number+1)*set_gain+set_offset
 
     elif exp_type == "CV":
 
@@ -226,13 +226,13 @@ def experiment(config_data, board, a0, a2, d9):
 
         first_steps_list = np.linspace(
             normalized_start, norm_first_turnover, num=step_number+1
-        )*setpoint_adjuster
+        )*set_gain+set_offset
         second_steps_list = np.linspace(
             norm_first_turnover, norm_second_turnover, num=step_number+1
-        )*setpoint_adjuster
+        )*set_gain+set_offset
         third_steps_list = np.linspace(
             norm_second_turnover, normalized_start, num=step_number+1
-        )*setpoint_adjuster
+        )*set_gain+set_offset
     else:
         sys.exit("Error! \nThe experiment_type field in config.yml is not an accepted value")
 

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -145,11 +145,12 @@ def experiment(config_data, board, a0, a2, d9):
 
     """
     # Constants for every experiment
-    conversion_factor, shunt_resistor, time_step, average_number, time_factor = cr.get_adv_params(
+    conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number, time_factor = cr.get_adv_params(
         config_data
     )
+
     # Check the values in adv_config.yml
-    for i in [conversion_factor, shunt_resistor, time_step, average_number, time_factor]:
+    for i in [conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number, time_factor]:
         if not cr.check_config_inputs(i):
             print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in adv.config.yml is not a number" + "\x1b[0m")
             sys.exit()
@@ -173,7 +174,7 @@ def experiment(config_data, board, a0, a2, d9):
         time_for_range = voltage_range / (sweep_rate / 1000)  # s
         step_number = int(time_for_range / time_per_measurement)
 
-        steps_list = np.linspace(normalized_start, normalized_end, num=step_number)
+        steps_list = np.linspace(normalized_start, normalized_end, num=step_number)*setpoint_adjuster
 
     elif exp_type == "CA":
 
@@ -187,7 +188,7 @@ def experiment(config_data, board, a0, a2, d9):
         time_for_range = time_for_range / time_factor
         step_number = int(time_for_range / time_per_measurement)
 
-        steps_list = [normalized_voltage] * step_number
+        steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number)*setpoint_adjuster
 
     elif exp_type == "CV":
 
@@ -218,13 +219,13 @@ def experiment(config_data, board, a0, a2, d9):
 
         first_steps_list = np.linspace(
             normalized_start, norm_first_turnover, num=first_step_number
-        )
+        )*setpoint_adjuster
         second_steps_list = np.linspace(
             norm_first_turnover, norm_second_turnover, num=second_step_number
-        )
+        )*setpoint_adjuster
         third_steps_list = np.linspace(
             norm_second_turnover, normalized_start, num=third_step_number
-        )
+        )*setpoint_adjuster
     else:
         sys.exit("Error! \nThe experiment_type field in config.yml is not an accepted value")
 

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -181,7 +181,6 @@ def experiment(config_data, board, a0, a2, d9):
             if not cr.check_config_inputs(i):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
-        sweep_rate = sweep_rate
         normalized_start = (start_voltage + 2.5) / 5  # for PWM
         normalized_end = (end_voltage + 2.5) / 5
 
@@ -199,7 +198,6 @@ def experiment(config_data, board, a0, a2, d9):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
         normalized_voltage = (voltage + 2.5) / 5
-        time_for_range = time_for_range
 
         steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number+1)*setpoint_adjuster
 
@@ -213,7 +211,7 @@ def experiment(config_data, board, a0, a2, d9):
             if not cr.check_config_inputs(i):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
-        sweep_rate = sweep_rate
+                
         normalized_start = (start_voltage + 2.5) / 5
         norm_first_turnover = (first_turnover + 2.5) / 5
         norm_second_turnover = (second_turnover + 2.5) / 5

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -34,14 +34,15 @@ def start_exp(d9, normalized_start, data):
 
     """
     d9.write(normalized_start)
-    cr.get_rest(data)
+    rest_time = cr.get_rest(data)
+    time.sleep(rest_time)
     start_time = time.time()
 
     return start_time
 
 
 def read_write(
-    start_time, d9, a0, a2, steps_list, average, line, time_step, cf, sr, config_data
+    start_time, d9, a0, a2, step_number, steps_list, time_for_range, average, line, time_step, cf, sr, config_data
 ):
     """
     Writes voltages to pin 9 using d9, reads voltages from pin 0 and 2 using a0
@@ -79,7 +80,14 @@ def read_write(
     nothing
 
     """
-
+    
+    starting_time = time.time()
+    ending_time = starting_time + time_for_range
+    times_list = np.linspace(starting_time, ending_time, num=step_number)
+    times_diff_list = [x - starting_time for x in times_list]
+    times_diff_list.append(0)
+    t = 1
+    
     for x in steps_list:
 
         # update time
@@ -90,7 +98,7 @@ def read_write(
         i = 0
         voltage_catcher = 0
         current_catcher = 0
-
+        
         while i < average:
             d9.write(x)  # Writes Value Between 0 and 1 (-2.5V to 2.5V) 256 possible
             time.sleep(time_step)
@@ -98,13 +106,10 @@ def read_write(
                 a0.read()
             )  # Reads Value Between 0 and 1 (-2.5V to 2.5V) 1024 possible
             pin2value = a2.read()
-
             real_voltage = (pin0value - 0.5) * -1 * cf
             real_current = ((pin2value - 0.5) * -1 * cf) / sr
-
             voltage_catcher = voltage_catcher + real_voltage
             current_catcher = current_catcher + real_current
-
             i = i + 1
 
         voltage_average = voltage_catcher / average
@@ -112,9 +117,17 @@ def read_write(
         voltages.append(voltage_average)
         currents.append(current_average)
         collected_data = zip(times, voltages, currents)
-        plot_updater(config_data, collected_data, line)
-
-
+        plot_updater(config_data, collected_data, line)  
+        rel_time = 0
+        
+        while rel_time < times_diff_list[t]:
+        
+                time.sleep(time_step)
+                now_time = time.time()
+                rel_time = now_time-start_time
+        
+        t = t+1
+        
 def experiment(config_data, board, a0, a2, d9):
     """
     Determines which experiment to run and applies the appropriate voltages
@@ -145,12 +158,14 @@ def experiment(config_data, board, a0, a2, d9):
 
     """
     # Constants for every experiment
-    conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number, time_factor = cr.get_adv_params(
+    conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number = cr.get_adv_params(
         config_data
     )
+    
+    step_number = cr.get_steps(config_data)
 
-    # Check the values in adv_config.yml
-    for i in [conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number, time_factor]:
+    # Check the values in advanced parameters in config.yml
+    for i in [conversion_factor, setpoint_adjuster, shunt_resistor, time_step, average_number]:
         if not cr.check_config_inputs(i):
             print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in adv.config.yml is not a number" + "\x1b[0m")
             sys.exit()
@@ -166,13 +181,12 @@ def experiment(config_data, board, a0, a2, d9):
             if not cr.check_config_inputs(i):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
-        sweep_rate = sweep_rate * time_factor
+        sweep_rate = sweep_rate
         normalized_start = (start_voltage + 2.5) / 5  # for PWM
         normalized_end = (end_voltage + 2.5) / 5
 
         voltage_range = abs(end_voltage - start_voltage)  # V
         time_for_range = voltage_range / (sweep_rate / 1000)  # s
-        step_number = int(time_for_range / time_per_measurement)
 
         steps_list = np.linspace(normalized_start, normalized_end, num=step_number)*setpoint_adjuster
 
@@ -185,8 +199,7 @@ def experiment(config_data, board, a0, a2, d9):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
         normalized_voltage = (voltage + 2.5) / 5
-        time_for_range = time_for_range / time_factor
-        step_number = int(time_for_range / time_per_measurement)
+        time_for_range = time_for_range
 
         steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number)*setpoint_adjuster
 
@@ -200,7 +213,7 @@ def experiment(config_data, board, a0, a2, d9):
             if not cr.check_config_inputs(i):
                 print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in config.yml is not a number" + "\x1b[0m")
                 sys.exit()
-        sweep_rate = sweep_rate * time_factor
+        sweep_rate = sweep_rate
         normalized_start = (start_voltage + 2.5) / 5
         norm_first_turnover = (first_turnover + 2.5) / 5
         norm_second_turnover = (second_turnover + 2.5) / 5
@@ -213,18 +226,14 @@ def experiment(config_data, board, a0, a2, d9):
         second_time_range = second_voltage_range / (sweep_rate / 1000)  # s
         third_time_range = third_voltage_range / (sweep_rate / 1000)  # s
 
-        first_step_number = int(first_time_range / time_per_measurement)
-        second_step_number = int(second_time_range / time_per_measurement)
-        third_step_number = int(third_time_range / time_per_measurement)
-
         first_steps_list = np.linspace(
-            normalized_start, norm_first_turnover, num=first_step_number
+            normalized_start, norm_first_turnover, num=step_number
         )*setpoint_adjuster
         second_steps_list = np.linspace(
-            norm_first_turnover, norm_second_turnover, num=second_step_number
+            norm_first_turnover, norm_second_turnover, num=step_number
         )*setpoint_adjuster
         third_steps_list = np.linspace(
-            norm_second_turnover, normalized_start, num=third_step_number
+            norm_second_turnover, normalized_start, num=step_number
         )*setpoint_adjuster
     else:
         sys.exit("Error! \nThe experiment_type field in config.yml is not an accepted value")
@@ -244,7 +253,9 @@ def experiment(config_data, board, a0, a2, d9):
             d9,
             a0,
             a2,
+            step_number,
             steps_list,
+            time_for_range,
             average_number,
             line,
             time_step,
@@ -264,7 +275,9 @@ def experiment(config_data, board, a0, a2, d9):
             d9,
             a0,
             a2,
+            step_number,
             steps_list,
+            time_for_range,
             average_number,
             line,
             time_step,
@@ -284,7 +297,9 @@ def experiment(config_data, board, a0, a2, d9):
             d9,
             a0,
             a2,
+            step_number,
             first_steps_list,
+            first_time_range,
             average_number,
             line,
             time_step,
@@ -297,7 +312,9 @@ def experiment(config_data, board, a0, a2, d9):
             d9,
             a0,
             a2,
+            step_number,
             second_steps_list,
+            second_time_range,
             average_number,
             line,
             time_step,
@@ -310,7 +327,9 @@ def experiment(config_data, board, a0, a2, d9):
             d9,
             a0,
             a2,
+            step_number,
             third_steps_list,
+            third_time_range,
             average_number,
             line,
             time_step,

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -241,6 +241,8 @@ def experiment(config_data, board, a0, a2, d9):
     line = plot_initializer(config_data)
 
     # Main experiment part
+    
+    pin_objects = (d9, a0, a2)
 
     if exp_type == "LSV":
 
@@ -248,9 +250,7 @@ def experiment(config_data, board, a0, a2, d9):
 
         read_write(
             start_time,
-            d9,
-            a0,
-            a2,
+            *pin_objects,
             step_number,
             steps_list,
             time_for_range,
@@ -270,9 +270,7 @@ def experiment(config_data, board, a0, a2, d9):
 
         read_write(
             start_time,
-            d9,
-            a0,
-            a2,
+            *pin_objects
             step_number,
             steps_list,
             time_for_range,
@@ -292,9 +290,7 @@ def experiment(config_data, board, a0, a2, d9):
 
         read_write(
             start_time,
-            d9,
-            a0,
-            a2,
+            *pin_objects
             step_number,
             first_steps_list,
             first_time_range,
@@ -307,9 +303,7 @@ def experiment(config_data, board, a0, a2, d9):
         )
         read_write(
             start_time,
-            d9,
-            a0,
-            a2,
+            *pin_objects
             step_number,
             second_steps_list,
             second_time_range,
@@ -322,9 +316,7 @@ def experiment(config_data, board, a0, a2, d9):
         )
         read_write(
             start_time,
-            d9,
-            a0,
-            a2,
+            *pin_objects
             step_number,
             third_steps_list,
             third_time_range,

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -165,7 +165,7 @@ def experiment(config_data, board, a0, a2, d9):
     step_number = cr.get_steps(config_data)
 
     # Check the values in advanced parameters in config.yml
-    for i in [conversion_factor, setpoint_gain, setpoint_offset, shunt_resistor, time_step, average_number]:
+    for i in [conversion_factor, set_gain, set_offset, shunt_resistor, time_step, average_number]:
         if not cr.check_config_inputs(i):
             print("\x1b[0;31;0m" + "Error! \nThe value ", i, " in adv.config.yml is not a number" + "\x1b[0m")
             sys.exit()

--- a/pytentiostat/tester.py
+++ b/pytentiostat/tester.py
@@ -83,7 +83,7 @@ def read_write(
     
     starting_time = time.time()
     ending_time = starting_time + time_for_range
-    times_list = np.linspace(starting_time, ending_time, num=step_number)
+    times_list = np.linspace(starting_time, ending_time, num=step_number+1)
     times_diff_list = [x - starting_time for x in times_list]
     times_diff_list.append(0)
     t = 1
@@ -188,7 +188,7 @@ def experiment(config_data, board, a0, a2, d9):
         voltage_range = abs(end_voltage - start_voltage)  # V
         time_for_range = voltage_range / (sweep_rate / 1000)  # s
 
-        steps_list = np.linspace(normalized_start, normalized_end, num=step_number)*setpoint_adjuster
+        steps_list = np.linspace(normalized_start, normalized_end, num=step_number+1)*setpoint_adjuster
 
     elif exp_type == "CA":
 
@@ -201,7 +201,7 @@ def experiment(config_data, board, a0, a2, d9):
         normalized_voltage = (voltage + 2.5) / 5
         time_for_range = time_for_range
 
-        steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number)*setpoint_adjuster
+        steps_list = np.linspace(normalized_voltage, normalized_voltage, step_number+1)*setpoint_adjuster
 
     elif exp_type == "CV":
 
@@ -227,13 +227,13 @@ def experiment(config_data, board, a0, a2, d9):
         third_time_range = third_voltage_range / (sweep_rate / 1000)  # s
 
         first_steps_list = np.linspace(
-            normalized_start, norm_first_turnover, num=step_number
+            normalized_start, norm_first_turnover, num=step_number+1
         )*setpoint_adjuster
         second_steps_list = np.linspace(
-            norm_first_turnover, norm_second_turnover, num=step_number
+            norm_first_turnover, norm_second_turnover, num=step_number+1
         )*setpoint_adjuster
         third_steps_list = np.linspace(
-            norm_second_turnover, normalized_start, num=step_number
+            norm_second_turnover, normalized_start, num=step_number+1
         )*setpoint_adjuster
     else:
         sys.exit("Error! \nThe experiment_type field in config.yml is not an accepted value")


### PR DESCRIPTION
Adds setpoint adjuster factor to allow for calibrating the setpoint target to make the input voltages match what is actually applied. In sum, should now match experiment set and will also match external measurement by a multimeter within instrumental error.