### PR TITLE
Use case using default config for alpha release

### DIFF
--- a/examples/dev/Alpha_Config_UC
+++ b/examples/dev/Alpha_Config_UC
@@ -1,0 +1,39 @@
+## Use Case: Running default config on the JUAMI Potentiostat for Alpha release.
+Intended User: Graduate student (GS) familiar with dev team and basic electrochemistry concepts. The instructions in this UC assume that the student has a resistor they can attach clips to.
+Assumes little to no knowledge of python. Assumes access to a Windows computer.
+
+### Before Installation: 
+1. Member of dev team gives GS a JUAMI Potentiostat with a 1kOhm resistor.
+1. GS installs python on their computer.
+
+### Installation:
+1. GS recieves email from member of dev team with link to release page.
+1. GS follow instructions on release page to install pytentiostat program.
+
+### Experimental Setup:
+1. GS plugs the USB cable into the computer and the potentiostat.
+1. GS attaches alligator clips to the resistor; one side with the working electrode and the other side with counter and reference Electrodes.
+
+### Program Setup:
+1. GS copies the default example config file to an easy to navigate to directory (WD).
+1. GS opens up a console window.
+1. GS navigates to WD.
+1. GS types command pytentiostat.
+
+### Pytentiostat Operation:
+1. Pytentiostat prints "Welcome to the JUAMI pytentiostat interface!".
+1. Pyentiostat prompts "Press enter to connect to a JUAMI potentiostat.".
+1. GS presses enter.
+1. Pytentiostat prints "Searching for potentiostat...".
+1. Pyentiostat prints "Pytentiostat connected COM. Reading configuration file...".
+1. Pytentiostat prints "Press enter to load the config file".
+1. GS presses enter.
+1. Pytentiostat prints "Press enter to start the experiment".
+1. Pytentiostat runs experiment in config.
+1. Pyentiostat displays plot of real-time data to user.
+1. After running experiment, pytentiostat promopts "Would you like to save the data? [y/n]".
+1. GS types y.
+1. Pytentiostat saves the data to their desktop.
+1. Pytentiostat prompts if user wants to run another experiment.
+1. GS types n.
+1. Pytentiostat program closes.


### PR DESCRIPTION
This is a use case for a simple operation of the pytentiostat that should be satisfied by the program upon alpha release. This PR also sets up a directory for future use cases in examples/dev/.