### PR TITLE
Identifying juami

### DIFF
--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -47,10 +47,10 @@ def _initialize_arduino(com):
 
 
     except:
-        sys.exit("Error: Could not open port Arduino Uno is connected to. Exiting…")
+        sys.exit("ERROR: Could not open port Arduino Uno is connected to. Exiting…")
 
     if board.firmware == 'pytentiostat_firmata.ino':  # check if the board have the right firmware
-        print("INFO: Pytentiostat connected to {}.\n".format(com))
+        print("INFO: Pytentiostat connected to {}.".format(com))
     else:
         sys.exit("ERROR: Arduino Uno connected does not have correct firmware uploaded. Exitining...")
     return board

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -20,16 +20,16 @@ def _load_arduino():
         the COM port the arduino is connected to.
     """
     print("Searching for potentiostat...")
-    ports = list(serial.tools.list_ports.comports())
+    ports = list(serial.tools.list_ports.grep(r'tty|Arduino|COM'))
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if re.search("tty|Arduino Uno|COM",p.description) is not None:
+        if re.match(r'tty|Arduino|COM',p.description) is not None:
             com = p.device
             n_arduinos += 1
     if n_arduinos > 1:
         sys.exit("More than one Arduino Uno found. Exiting...")
     if n_arduinos == 0:
-        sys.exit("No Arduino Uno found. Exiting...")
+        sys.exit("No JUAMI potentiostat found. Exiting...")
     return com
 
 
@@ -43,15 +43,13 @@ def _initialize_arduino(com):
     try:
         board = Arduino(com,
                         baudrate=_BAUD_RATE)  # opens communication to Arduino
-
-
+        if board.firmware == 'pytentiostat_firmata.ino':
+            print("Pytentiostat connected to {}.\n".format(
+            com))
+        else:
+            print('the board is not a Pytentiostat')
     except:
         sys.exit("Error. Could not open COM port")
-
-    if board.firmware == 'pytentiostat_firmata.ino':  # check if the board have the right firmware
-        print("Pytentiostat connected to {}.\n".format(com))
-    else:
-        sys.exit('the board is not a pytentiostat')
     return board
 
 

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -1,5 +1,5 @@
 import sys
-
+import re
 from pyfirmata import Arduino, util
 import matplotlib.pyplot as plt
 import serial.tools.list_ports
@@ -20,10 +20,10 @@ def _load_arduino():
         the COM port the arduino is connected to.
     """
     print("Searching for potentiostat...")
-    ports = list(serial.tools.list_ports.comports())
+    ports = list(serial.tools.list_ports.grep(r"tty|Arduino|COM"))#use grep to cover all posible cases
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if "Arduino Uno" in p.description:
+        if re.match(r"tty|Arduino|COM",p.description) is not None: # The description "Arduino Uno" do not match with the name of the port
             com = p.device
             n_arduinos += 1
     if n_arduinos > 1:
@@ -48,6 +48,9 @@ def _initialize_arduino(com):
             com))
     except:
         sys.exit("Error. Could not open COM port")
+
+    if board.firmware != 'pytentiostat_firmata.ino':  # check if the board have the right firmware
+        sys.exit('the board is not a pytentiostat')
     return board
 
 

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -26,10 +26,11 @@ def _load_arduino():
         if re.search("tty|Arduino Uno|COM",p.description) is not None:
             com = p.device
             n_arduinos += 1
+            print("INFO: Arduino Uno found at port.\n".format(com))
     if n_arduinos > 1:
-        sys.exit("More than one Arduino Uno found. Exiting...")
+        sys.exit("ERROR: More than one Arduino Uno found. Exiting...")
     if n_arduinos == 0:
-        sys.exit("No Arduino Uno found. Exiting...")
+        sys.exit("ERROR: No Arduino Uno found. Exiting...")
     return com
 
 
@@ -46,12 +47,12 @@ def _initialize_arduino(com):
 
 
     except:
-        sys.exit("Error. Could not open COM port")
+        sys.exit("Error: Could not open port Arduino Uno is connected to. Exiting…")
 
     if board.firmware == 'pytentiostat_firmata.ino':  # check if the board have the right firmware
-        print("Pytentiostat connected to {}.\n".format(com))
+        print("INFO: Pytentiostat connected to {}.\n".format(com))
     else:
-        sys.exit('the board is not a pytentiostat')
+        sys.exit("ERROR: Arduino Uno connected does not have correct firmware uploaded. Exitining...")
     return board
 
 

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -20,16 +20,16 @@ def _load_arduino():
         the COM port the arduino is connected to.
     """
     print("Searching for potentiostat...")
-    ports = list(serial.tools.list_ports.grep(r'tty|Arduino|COM'))
+    ports = list(serial.tools.list_ports.comports())
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if re.match(r'tty|Arduino|COM',p.description) is not None:
+        if re.search("tty|Arduino Uno|COM",p.description) is not None:
             com = p.device
             n_arduinos += 1
     if n_arduinos > 1:
         sys.exit("More than one Arduino Uno found. Exiting...")
     if n_arduinos == 0:
-        sys.exit("No JUAMI potentiostat found. Exiting...")
+        sys.exit("No Arduino Uno found. Exiting...")
     return com
 
 
@@ -43,13 +43,16 @@ def _initialize_arduino(com):
     try:
         board = Arduino(com,
                         baudrate=_BAUD_RATE)  # opens communication to Arduino
-        if board.firmware == 'pytentiostat_firmata.ino':
-            print("Pytentiostat connected to {}.\n".format(
-            com))
-        else:
-            print('the board is not a Pytentiostat')
+
+
     except:
         sys.exit("Error. Could not open COM port")
+
+    if board.firmware == 'pytentiostat_firmata.ino':  # check if the board have the right firmware
+        print("Pytentiostat connected to {}.\n".format(
+            com))
+    else:
+        sys.exit('the board is not a pytentiostat')
     return board
 
 

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -23,12 +23,12 @@ def _load_arduino():
     ports = list(serial.tools.list_ports.comports())
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if re.search("tty|Arduino Uno|COM",p.description) is not None:
+        if re.search("ttyACM|Arduino Uno",p.description) is not None:
             com = p.device
             n_arduinos += 1
             print("INFO: Arduino Uno found at port.\n".format(com))
     if n_arduinos > 1:
-        sys.exit("ERROR: More than one Arduino Uno found. Exiting...")
+        sys.exit("ERROR: More than one Arduino Uno found. Please unplug any other Arduinos and retry.")
     if n_arduinos == 0:
         sys.exit("ERROR: No Arduino Uno found. Exiting...")
     return com

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -1,5 +1,5 @@
 import sys
-
+import re
 from pyfirmata import Arduino, util
 import matplotlib.pyplot as plt
 import serial.tools.list_ports
@@ -20,10 +20,10 @@ def _load_arduino():
         the COM port the arduino is connected to.
     """
     print("Searching for potentiostat...")
-    ports = list(serial.tools.list_ports.comports())
+    ports = list(serial.tools.list_ports.grep(r'tty|Arduino|COM'))
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if "Arduino Uno" in p.description:
+        if re.match(r'tty|Arduino|COM',p.description) is not None:
             com = p.device
             n_arduinos += 1
     if n_arduinos > 1:
@@ -43,8 +43,11 @@ def _initialize_arduino(com):
     try:
         board = Arduino(com,
                         baudrate=_BAUD_RATE)  # opens communication to Arduino
-        print("Pytentiostat connected to {}.\n".format(
+        if board.firmware == 'pytentiostat_firmata.ino':
+            print("Pytentiostat connected to {}.\n".format(
             com))
+        else:
+            print('the board is not a Pytentiostat')
     except:
         sys.exit("Error. Could not open COM port")
     return board

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -1,5 +1,5 @@
 import sys
-import re
+
 from pyfirmata import Arduino, util
 import matplotlib.pyplot as plt
 import serial.tools.list_ports
@@ -20,10 +20,10 @@ def _load_arduino():
         the COM port the arduino is connected to.
     """
     print("Searching for potentiostat...")
-    ports = list(serial.tools.list_ports.grep(r"tty|Arduino|COM"))#use grep to cover all posible cases
+    ports = list(serial.tools.list_ports.comports())
     n_arduinos = 0
     for p in ports:  # Checking for Arduino Unos connected
-        if re.match(r"tty|Arduino|COM",p.description) is not None: # The description "Arduino Uno" do not match with the name of the port
+        if "Arduino Uno" in p.description:
             com = p.device
             n_arduinos += 1
     if n_arduinos > 1:
@@ -38,7 +38,6 @@ def _initialize_arduino(com):
     Creates board object with Arduino(). If the connection fails it prints an error message and exits.
     Parameters
     ----------
-    com: string
         the COM port that the potentiostat is connected to.
     """
     try:
@@ -48,9 +47,6 @@ def _initialize_arduino(com):
             com))
     except:
         sys.exit("Error. Could not open COM port")
-
-    if board.firmware != 'pytentiostat_firmata.ino':  # check if the board have the right firmware
-        sys.exit('the board is not a pytentiostat')
     return board
 
 

--- a/pytentiostat/routines.py
+++ b/pytentiostat/routines.py
@@ -49,8 +49,7 @@ def _initialize_arduino(com):
         sys.exit("Error. Could not open COM port")
 
     if board.firmware == 'pytentiostat_firmata.ino':  # check if the board have the right firmware
-        print("Pytentiostat connected to {}.\n".format(
-            com))
+        print("Pytentiostat connected to {}.\n".format(com))
     else:
         sys.exit('the board is not a pytentiostat')
     return board

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -12,7 +12,6 @@ class Dummy_port:
 class Dummy_arduino:
     def __init__(self):
         self.name = None
-        self.firmware = None
 
 def test_load_arduino():
     good_port = Dummy_port()
@@ -37,26 +36,14 @@ def test_load_arduino():
 
 
 def test_initialize_arduino():
-    pot = Dummy_arduino()
-    pot.name = "good_arduino"
-    pot.firmware = "pytentiostat_firmata.ino"
-    no_pot = Dummy_arduino()
-    no_pot.name = 'bad_arduino'
-    no_pot.firmware = "zaraza"
+    da = Dummy_arduino()
+    da.name = "good_arduino"
+    da.firmware = "pytentiostat_firmata.ino"
     with pytest.raises(SystemExit):
         _initialize_arduino("bad_port")
     with mock.patch(
         "pytentiostat.routines.Arduino",
-        return_value=pot,
+        return_value=da,
     ):
         ard = _initialize_arduino("good_port")
         assert ard.name == "good_arduino"
-    with pytest.raises(SystemExit):
-        with mock.patch(
-            "pytentiostat.routines.Arduino",
-            return_value=no_pot,
-        ):
-            ard = _initialize_arduino("good_port")
-            assert ard.name == "bad_arduino"
-
-

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -12,6 +12,7 @@ class Dummy_port:
 class Dummy_arduino:
     def __init__(self):
         self.name = None
+        self.firmware = None
 
 def test_load_arduino():
     good_port = Dummy_port()
@@ -36,15 +37,26 @@ def test_load_arduino():
 
 
 def test_initialize_arduino():
-    da = Dummy_arduino()
-    da.name = "good_arduino"
-    da.firmware = "pytentiostat_firmata.ino"
+    pot = Dummy_arduino()
+    pot.name = "good_arduino"
+    pot.firmware = "pytentiostat_firmata.ino"
+    no_pot = Dummy_arduino()
+    no_pot.name = 'bad_arduino'
+    no_pot.firmware = "zaraza"
     with pytest.raises(SystemExit):
         _initialize_arduino("bad_port")
     with mock.patch(
         "pytentiostat.routines.Arduino",
-        return_value=da,
+        return_value=pot,
     ):
         ard = _initialize_arduino("good_port")
         assert ard.name == "good_arduino"
-        assert ard.firmware == "pytentiostat_firmata.ino"
+    with pytest.raises(SystemExit):
+        with mock.patch(
+            "pytentiostat.routines.Arduino",
+            return_value=no_pot,
+        ):
+            ard = _initialize_arduino("good_port")
+            assert ard.name == "bad_arduino"
+
+

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -47,4 +47,4 @@ def test_initialize_arduino():
     ):
         ard = _initialize_arduino("good_port")
         assert ard.name == "good_arduino"
-        assert ard.firmware == "pytensiostat_firmata.ino"
+        assert ard.firmware == "pytentiostat_firmata.ino"

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -38,7 +38,7 @@ def test_load_arduino():
 def test_initialize_arduino():
     da = Dummy_arduino()
     da.name = "good_arduino"
-
+    da.firmware = "pytentiostat_firmata.ino"
     with pytest.raises(SystemExit):
         _initialize_arduino("bad_port")
     with mock.patch(

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -47,3 +47,4 @@ def test_initialize_arduino():
     ):
         ard = _initialize_arduino("good_port")
         assert ard.name == "good_arduino"
+        assert ard.firmware == "pytensiostat_firmata.ino"


### PR DESCRIPTION
 I had to change _load_arduino () to recognize my port in my Linux machine. Then I add a new checkpoint to verify that the firmware correspond to the one we want. I had to remove the declaration of the pin 9 as out in the setup the pytentiostat_firmata.ino to use the board.firmware attribute because with the original it returns None. I don't know if it's a little confusing the result because if the wrong firmata was uploaded into the board it allows you to run the config file after telling you that the board is not a pytentiostat.
